### PR TITLE
Fix undefined posts error on post create.

### DIFF
--- a/resources/js/services/Post.js
+++ b/resources/js/services/Post.js
@@ -43,11 +43,9 @@ class Post extends Service {
             };
 
             axios(requestOptions).then(response => {
-                this.handleSuccessfulCreate(response.data.data);
-
                 return resolve();
             }).catch(error => {
-                this.handleUnsuccessfulCreate(error.response);
+                console.log(error.response);
 
                 return reject();
             });
@@ -104,15 +102,6 @@ class Post extends Service {
         formData.append('published_at', published_at);
 
         return formData;
-    }
-
-    handleSuccessfulCreate (post) {
-        store.posts.push(post);
-        this.orderPostsBy('created_at', 'desc');
-    }
-
-    handleUnsuccessfulCreate (error) {
-        console.log(error);
     }
 
     handleSuccessfulUpdate (data) {


### PR DESCRIPTION
- When going straight to "new post" page, store.posts is undefined, so we can't push the new post. Instead, simply resolve and show success message, as posts will be fetched after redirect.